### PR TITLE
Add missing sound event to sounds.json autocompletions

### DIFF
--- a/packages/auto_completions/simple/sounds.json
+++ b/packages/auto_completions/simple/sounds.json
@@ -57,7 +57,7 @@
 				"sleep": "$simple.general.sound_object",
 				"spit": "$simple.general.sound_object",
 				"warn": "$simple.general.sound_object",
-				"scream": "$simple.general.sound_object"
+				"scream": "$simple.general.sound_object",
 				"charge": "$simple.general.sound_object"
 			}
 		},

--- a/packages/auto_completions/simple/sounds.json
+++ b/packages/auto_completions/simple/sounds.json
@@ -58,6 +58,7 @@
 				"spit": "$simple.general.sound_object",
 				"warn": "$simple.general.sound_object",
 				"scream": "$simple.general.sound_object"
+				"charge": "$simple.general.sound_object"
 			}
 		},
 		"entities": {


### PR DESCRIPTION
`sounds.json` was missing an autocompletion for the `charge` entity sound event, used by Vexes. Thanks to Correen from bridge. Discord for catching this!