### PR TITLE
Update BP item autocompletions

### DIFF
--- a/packages/auto_completions/item/components.json
+++ b/packages/auto_completions/item/components.json
@@ -533,5 +533,13 @@
 			"is_equipped": "$entity.components",
 			"is_not_equipped": "$entity.components"
 		}
-	}
+	},
+	"$versioned_template.minecraft:display_name": [
+		{
+			"$if": "$format_version >= 1.16.100",
+			"$data": {
+				"value": { "@meta": { "is_value": true } }
+			}
+		}
+	]
 }


### PR DESCRIPTION
`minecraft:display_name` now works in behavior item JSON's, according to SyKo from bridge. Discord.