### PR TITLE
Correct typo in item event autocompletions

### DIFF
--- a/packages/auto_completions/item/event.json
+++ b/packages/auto_completions/item/event.json
@@ -40,7 +40,7 @@
 	"teleport": {
 		"target": ["holder"],
 		"avoid_water": "$general.boolean",
-		"destintion": {
+		"destination": {
 			"$dynamic.list.index_triple": "$general.number"
 		},
 		"land_on_block": "$general.boolean",


### PR DESCRIPTION
Change `destintion` to `destination` in the item events' auto-completions. Thanks to [ExDrill](https://discord.com/users/455067095827218452) for finding this, and @7dev7urandom for suggesting I fix this!