### PR TITLE
Update event.json

### DIFF
--- a/packages/auto_completions/block/event.json
+++ b/packages/auto_completions/block/event.json
@@ -10,7 +10,8 @@
 	},
 	"sequence": {
 		"$dynamic.list.next_index": {
-			"$load": "$block.event"
+			"$load": "$block.event",
+			"condition": "$molang.embedded"
 		}
 	},
 	"transform_item": {


### PR DESCRIPTION
Added an option for a condition in block event sequences.
Example of a use:
{
	"sequence": [
		{
			"condition": "query.is_sneaking",
			"set_block": {
				"block_type": "minecraft:gravel"
			}
		}
	]
}