### PR TITLE
Update feature_rule/main.json

### DIFF
--- a/packages/auto_completions/feature_rule/main.json
+++ b/packages/auto_completions/feature_rule/main.json
@@ -10,7 +10,11 @@
         },
         "conditions": {
             "placement_pass": "$feature_rule.general.passes",
-            "minecraft:biome_filter": "$spawn_rule.components.minecraft:biome_filter"
+            "minecraft:biome_filter": {
+                "$dynamic.list.next_index": {
+                    "$load": "$spawn_rule.components.minecraft:biome_filter"
+                }
+            }
         },
         "distribution": {
             "iterations": "$general.number",


### PR DESCRIPTION
Fix incorrect auto-completions for 'minecraft:biome_filter'

Not 100% sure I used the correct syntax for auto-completions