### PR TITLE
v1.1.34

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "bridge-data",
-	"version": "1.1.33",
+	"version": "1.1.34",
 	"description": "Provide data for the bridge. editor",
 	"main": "dist/auto-completions.js",
 	"scripts": {

--- a/packages/auto_completions/item/main.json
+++ b/packages/auto_completions/item/main.json
@@ -6,6 +6,7 @@
 			"validate": {
 				"confirm": "['1.16.200', '1.16.210', '1.16.220'].includes(Bridge.Node.data)",
 				"then": {
+					"is_warning": true,
 					"show": true,
 					"message": "This Format Version for items may produce unexpected results; use 1.16.100 instead, or if you are in beta use 1.17.0"
 				}

--- a/packages/auto_completions/item/main.json
+++ b/packages/auto_completions/item/main.json
@@ -4,10 +4,10 @@
 		"@meta": {
 			"is_value": true,
 			"validate": {
-				"confirm": "Bridge.Version.compare(Bridge.Node.data, '1.16.100', '>')",
+				"confirm": "['1.16.200', '1.16.210', '1.16.220'].includes(Bridge.Node.data)",
 				"then": {
 					"show": true,
-					"message": "Format version 1.16.200+ for items may produce unexpected results; use 1.16.100 instead"
+					"message": "This Format Version for items may produce unexpected results; use 1.16.100 instead, or if you are in beta use 1.17.0"
 				}
 			}
 		}

--- a/packages/auto_completions/molang/general.json
+++ b/packages/auto_completions/molang/general.json
@@ -192,7 +192,9 @@
 		"scoreboard",
 		"self",
 		"target",
-		"time_of_day"
+		"time_of_day",
+		"show_bottom",
+		"death_time"
 	],
 	"world_gen_query": ["heightmap", "above_top_solid"],
 	"variable": ["worldx", "worldz", "attack_time"],
@@ -225,7 +227,8 @@
 		"asin",
 		"pi",
 		"random_integer",
-		"hermite_blend"
+		"hermite_blend",
+		"min_angle"
 	],
 	"operator": [
 		"+",


### PR DESCRIPTION
# Changes:
- Updated to latest Minecraft beta
- Change item format version error to warning

# Fixes:
- Fixed item error when format version was blank