### PR TITLE
Update item auto-completions

### DIFF
--- a/packages/auto_completions/item/components.json
+++ b/packages/auto_completions/item/components.json
@@ -348,7 +348,8 @@
 				"on_consume": "$item.general.event_definition",
 				"nutrition": "$general.number",
 				"can_always_eat": "$general.boolean",
-				"saturation_modifier": "$item.general.saturation_modifier"
+				"saturation_modifier": "$item.general.saturation_modifier",
+				"using_converts_to": "$general.item_identifier"
 			}
 		},
 		{

--- a/packages/auto_completions/item/event.json
+++ b/packages/auto_completions/item/event.json
@@ -33,7 +33,20 @@
 		"target": ["holder"]
 	},
 	"transform_item": {
-		"transform": "$general.item_identifier"
+		"transform": {
+			"@import.value": "$general.item_identifier",
+			"@meta": {
+				"is_value": true,
+				"validate": {
+					"confirm": "true",
+					"then": {
+						"is_warning": true,
+						"show": true,
+						"message": "'transform_item' may crash the software when used; removing it is recommended"
+					}
+				}
+			}
+		}
 	},
 	"sequence": {
 		"$dynamic.list.next_index": {

--- a/packages/auto_completions/item/event.json
+++ b/packages/auto_completions/item/event.json
@@ -42,7 +42,7 @@
 					"then": {
 						"is_warning": true,
 						"show": true,
-						"message": "'transform_item' may crash the software when used; removing it is recommended"
+						"message": "'transform_item' may crash Minecraft when used; removing it is recommended"
 					}
 				}
 			}


### PR DESCRIPTION
- Add "using_converts_to" to "minecraft:food" 1.16.100+ auto-completions
- Provide error when "transform_item" is used